### PR TITLE
Add sunrise and sunset in WeatherForecast Class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.idea
 /vendor
 /composer.lock
 /phpunit.phar

--- a/Cmfcmf/OpenWeatherMap/WeatherForecast.php
+++ b/Cmfcmf/OpenWeatherMap/WeatherForecast.php
@@ -20,6 +20,7 @@ namespace Cmfcmf\OpenWeatherMap;
 
 use Cmfcmf\OpenWeatherMap;
 use Cmfcmf\OpenWeatherMap\Util\City;
+use Cmfcmf\OpenWeatherMap\Util\Sun;
 
 /**
  * Weather class returned by Cmfcmf\OpenWeatherMap->getWeather().
@@ -34,6 +35,13 @@ class WeatherForecast implements \Iterator
      * @var Util\City
      */
     public $city;
+
+    /**
+     * A sun object
+     *
+     * @var Util\Sun
+     */
+    public $sun;
 
     /**
      * The time of the last update of this weather data.
@@ -68,6 +76,7 @@ class WeatherForecast implements \Iterator
     public function __construct($xml, $units, $days)
     {
         $this->city = new City(-1, $xml->location->name, $xml->location->location['longitude'], $xml->location->location['latitude'], $xml->location->country);
+        $this->sun = new Sun(new \DateTime($xml->sun['rise']), new \DateTime($xml->sun['set']));
         $this->lastUpdate = new \DateTime($xml->meta->lastupdate);
 
         $counter = 0;

--- a/Examples/WeatherForecast.php
+++ b/Examples/WeatherForecast.php
@@ -44,6 +44,8 @@ echo "City: " . $forecast->city->name;
 echo "<br />\n";
 echo "LastUpdate: " . $forecast->lastUpdate->format('d.m.Y H:i');
 echo "<br />\n";
+echo "Sunrise : " . $forecast->sun->rise->format("H:i:s") . " Sunset : " . $forecast->sun->set->format("H:i:s");
+echo "<br />\n";
 echo "<br />\n";
 
 foreach ($forecast as $weather) {


### PR DESCRIPTION
If you wanted to get sunrise and sunset with getWeatherForecase, you had to call getWeather also, which causes double connection to openWeather.

Si on voulait le sunrise et le sunset avec getWeatherForecast, il était nécessaire d'appeler aussi getWeather, ce qui provoque une double connexion à openweather. 