### PR TITLE
fetch() => used curl, because file_get_contents() is not allowed to get ...

### DIFF
--- a/Cmfcmf/OpenWeatherMap/Fetcher/FileGetContentsFetcher.php
+++ b/Cmfcmf/OpenWeatherMap/Fetcher/FileGetContentsFetcher.php
@@ -30,6 +30,11 @@ class FileGetContentsFetcher implements FetcherInterface
      */
     public function fetch($url)
     {
-        return file_get_contents($url);
+        $ch = curl_init();
+        curl_setopt($ch, CURLOPT_URL, $url);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+        $data = curl_exec($ch);
+        curl_close($ch);
+        return $data;
     }
 }


### PR DESCRIPTION
I changed fetch()
Now using cUrl, because file_get_contents() is not allowed to get data from url (security setting)