### PR TITLE
Possibility to inject curl options

### DIFF
--- a/Cmfcmf/OpenWeatherMap/Fetcher/CurlFetcher.php
+++ b/Cmfcmf/OpenWeatherMap/Fetcher/CurlFetcher.php
@@ -29,11 +29,20 @@ class CurlFetcher implements FetcherInterface
      */
     public function fetch($url)
     {
+        global $curl;
+        
         $ch = curl_init($url);
         $timeout = 5;
         curl_setopt($ch, CURLOPT_URL, $url);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
         curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, $timeout);
+        
+        if(isset($curl['options'])) {
+            foreach($curl['options'] as $k => $v) {
+                curl_setopt($ch, constant('CURLOPT_'.$k), $v);
+            }
+        }
+        
         $content = curl_exec($ch);
         curl_close($ch);
 

--- a/Cmfcmf/OpenWeatherMap/Fetcher/CurlFetcher.php
+++ b/Cmfcmf/OpenWeatherMap/Fetcher/CurlFetcher.php
@@ -37,8 +37,8 @@ class CurlFetcher implements FetcherInterface
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
         curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, $timeout);
         
-        if(isset($curl['options'])) {
-            foreach($curl['options'] as $k => $v) {
+        if (isset($curl['options'])) {
+            foreach ($curl['options'] as $k => $v) {
                 curl_setopt($ch, constant('CURLOPT_'.$k), $v);
             }
         }

--- a/Examples/Cache.php
+++ b/Examples/Cache.php
@@ -53,7 +53,7 @@ class ExampleCache extends AbstractCache
     public function isCached($url)
     {
         $path = $this->urlToPath($url);
-        if (!file_exists($path) || filectime($path) + $this->seconds < time()) {
+        if (!file_exists($path) || filemtime($path) + $this->seconds < time()) {
             echo "Weather data is NOT cached!\n";
 
             return false;


### PR DESCRIPTION
Do the possibility to inject curl options to the curl connection

Exemple: 
Proxy authentication
```php
$curl['options'] = [
  'PROXYAUTH' => CURLAUTH_NTLM,
  'HTTPPROXYTUNNEL' => true,
  'PROXY' => 'server.com',
  'PROXYPORT' => 1234,
  'PROXYUSERPWD' => 'user:password'
];
```