### PR TITLE
Fixed Sun Rise/Set bug on forecast

### DIFF
--- a/Cmfcmf/OpenWeatherMap/WeatherForecast.php
+++ b/Cmfcmf/OpenWeatherMap/WeatherForecast.php
@@ -81,7 +81,9 @@ class WeatherForecast implements \Iterator
         $counter = 0;
         foreach ($xml->forecast->time as $time) {
             $forecast = new Forecast($time, $units);
-            $forecast->city = $this->city;
+			$forecast->city = $this->city;
+			$forecast->sun = $this->sun;
+			$forecast->lastUpdate = $this->lastUpdate;
             $this->forecasts[] = $forecast;
 
             $counter++;

--- a/Cmfcmf/OpenWeatherMap/WeatherForecast.php
+++ b/Cmfcmf/OpenWeatherMap/WeatherForecast.php
@@ -81,9 +81,9 @@ class WeatherForecast implements \Iterator
         $counter = 0;
         foreach ($xml->forecast->time as $time) {
             $forecast = new Forecast($time, $units);
-			$forecast->city = $this->city;
-			$forecast->sun = $this->sun;
-			$forecast->lastUpdate = $this->lastUpdate;
+            $forecast->city = $this->city;
+            $forecast->sun = $this->sun;
+            $forecast->lastUpdate = $this->lastUpdate;
             $this->forecasts[] = $forecast;
 
             $counter++;


### PR DESCRIPTION
It was not setting sun rise/set properly and always defaulted to NOW for both rise and set.