### PR TITLE
Short array syntax has been added in PHP 5.4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "source": "https://github.com/cmfcmf/OpenWeatherMap-PHP-Api.git"
     },
     "require": {
-        "php": ">=5.3.0"
+        "php": ">=5.4.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
http://php.net/manual/en/migration54.new-features.php
Short array syntax has been added, e.g. $a = [1, 2, 3, 4]; or $a = ['one' => 1, 'two' => 2, 'three' => 3, 'four' => 4];.