### PR TITLE
Removed the 'not-so-forecast' measure

### DIFF
--- a/Cmfcmf/OpenWeatherMap/WeatherForecast.php
+++ b/Cmfcmf/OpenWeatherMap/WeatherForecast.php
@@ -78,16 +78,8 @@ class WeatherForecast implements \Iterator
         $this->sun = new Sun(new \DateTime($xml->sun['rise'], $utctz), new \DateTime($xml->sun['set'], $utctz));
         $this->lastUpdate = new \DateTime($xml->meta->lastupdate, $utctz);
 
-        $today = new \DateTime('now', $utctz);
-        $today->setTime(0, 0, 0);
         $counter = 0;
         foreach ($xml->forecast->time as $time) {
-            $date = new \DateTime(isset($time['day']) ? $time['day'] : $time['to'], $utctz);
-            if ($date < $today) {
-                // Sometimes OpenWeatherMap returns results which aren't real
-                // forecasts. The best we can do is to ignore them.
-                continue;
-            }
             $forecast = new Forecast($time, $units);
             $forecast->city = $this->city;
             $forecast->sun = $this->sun;

--- a/tests/FakeData.php
+++ b/tests/FakeData.php
@@ -65,7 +65,7 @@ class FakeData
         </meta>
         <sun rise="2016-12-28T07:17:18" set="2016-12-28T14:59:55"></sun>
         <forecast>
-            <time day="2016-12-20">
+            <time day="' . date('Y-m-d', time() + 0) . '">
                 <symbol number="500" name="light rain" var="10d"></symbol>
                 <precipitation value="0.25" type="rain"></precipitation>
                 <windDirection deg="315" code="NW" name="Northwest"></windDirection>
@@ -75,7 +75,7 @@ class FakeData
                 <humidity value="97" unit="%"></humidity>
                 <clouds value="overcast clouds" all="92" unit="%"></clouds>
             </time>
-            <time day="' . date('Y-m-d') . '">
+            <time day="' . date('Y-m-d', time() + 3600) . '">
                 <symbol number="500" name="light rain" var="10d"></symbol>
                 <precipitation value="0.24" type="rain"></precipitation>
                 <windDirection deg="253" code="WSW" name="West-southwest"></windDirection>

--- a/tests/OpenWeatherMap/WeatherForecastTest.php
+++ b/tests/OpenWeatherMap/WeatherForecastTest.php
@@ -55,19 +55,12 @@ class WeatherForecastTest extends \PHPUnit_Framework_TestCase
 
     public function testNext()
     {
-        $this->forecast->rewind();
         $this->forecast->next();
-        $result = $this->forecast->valid();
-
-        $this->assertFalse($result);
+        $this->assertTrue($this->forecast->valid());
     }
 
     public function testValid()
     {
-        $this->forecast->rewind();
-        $this->forecast->next();
-        $result = $this->forecast->valid();
-
-        $this->assertFalse($result);
+        $this->assertTrue($this->forecast->valid());
     }
 }


### PR DESCRIPTION
This is a PR for #121. This removes the 'not-so-forecast' measure in `\Cmfcmf\OpenWeatherMap\WeatherForecast`.  
In summary, when we fixed #119, I believe that the 'not-so-forecast' problem fixed by #64 may have been *gone* because the code used to remove such forecasts involved a timezone-related issue.

Currently, this PR breaks 2 assertions in `WeatherForecastTest` because these run under the assumption of the measure being present. If we can be sure that the 'not-so-forecasts' aren't there in the first place, we can modify the test as well.  
If the measure is found to be necessary, I'll close this PR.