### PR TITLE
[BUGFIX] abs() in timezone method fails if arg is simplexmlelement

### DIFF
--- a/Cmfcmf/OpenWeatherMap/Util/City.php
+++ b/Cmfcmf/OpenWeatherMap/Util/City.php
@@ -67,7 +67,7 @@ class City extends Location
         $this->name = isset($name) ? (string)$name : null;
         $this->country = isset($country) ? (string)$country : null;
         $this->population = isset($population) ? (int)$population : null;
-        $this->timezone = isset($timezoneOffset) ? new \DateTimeZone(self::timezoneOffsetInSecondsToHours($timezoneOffset)) : null;
+        $this->timezone = isset($timezoneOffset) ? new \DateTimeZone(self::timezoneOffsetInSecondsToHours((int)$timezoneOffset)) : null;
 
         parent::__construct($lat, $lon);
     }


### PR DESCRIPTION
(i am using php 8.0 in my project)

The timezone can either be int or of type SimpleXMLElement:

![image](https://user-images.githubusercontent.com/7099583/90870170-7fb08e00-e399-11ea-85a7-c2f323d37bc0.png)

`floor(abs($offset) / 60)` only accepts `int`, thus the method fails to convert it
