### PR TITLE
Fixes deprecations errors on php 8.1

### DIFF
--- a/Cmfcmf/OpenWeatherMap/CurrentWeatherGroup.php
+++ b/Cmfcmf/OpenWeatherMap/CurrentWeatherGroup.php
@@ -55,6 +55,7 @@ class CurrentWeatherGroup implements \Iterator
     /**
      * @internal
      */
+    #[\ReturnTypeWillChange]
     public function rewind()
     {
         $this->position = 0;
@@ -63,6 +64,7 @@ class CurrentWeatherGroup implements \Iterator
     /**
      * @internal
      */
+    #[\ReturnTypeWillChange]
     public function current()
     {
         return $this->currentWeathers[$this->position];
@@ -71,6 +73,7 @@ class CurrentWeatherGroup implements \Iterator
     /**
      * @internal
      */
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return $this->current()->city->id;
@@ -79,6 +82,7 @@ class CurrentWeatherGroup implements \Iterator
     /**
      * @internal
      */
+    #[\ReturnTypeWillChange]
     public function next()
     {
         ++$this->position;
@@ -87,6 +91,7 @@ class CurrentWeatherGroup implements \Iterator
     /**
      * @internal
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return isset($this->currentWeathers[$this->position]);

--- a/Cmfcmf/OpenWeatherMap/Forecast.php
+++ b/Cmfcmf/OpenWeatherMap/Forecast.php
@@ -80,7 +80,7 @@ class Forecast extends CurrentWeather
         $this->clouds = new Unit($xml->clouds['all'], $xml->clouds['unit'], $xml->clouds['value']);
         $this->precipitation = new Unit($xml->precipitation['value'], null, $xml->precipitation['type']);
         $this->weather = new Weather($xml->symbol['number'], $xml->symbol['name'], $xml->symbol['var']);
-        $this->lastUpdate = new \DateTime($xml->lastupdate['value'], $utctz);
+        $this->lastUpdate = new \DateTime($xml->lastupdate['value'] ?? 'now', $utctz);
 
         if (isset($xml['from'])) {
             $this->time = new Time($xml['from'], $xml['to']);

--- a/Cmfcmf/OpenWeatherMap/Util/Unit.php
+++ b/Cmfcmf/OpenWeatherMap/Util/Unit.php
@@ -152,6 +152,7 @@ class Unit implements JsonSerializable
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [

--- a/Cmfcmf/OpenWeatherMap/WeatherForecast.php
+++ b/Cmfcmf/OpenWeatherMap/WeatherForecast.php
@@ -99,6 +99,7 @@ class WeatherForecast implements \Iterator
     /**
      * @internal
      */
+    #[\ReturnTypeWillChange]
     public function rewind()
     {
         $this->position = 0;
@@ -107,6 +108,7 @@ class WeatherForecast implements \Iterator
     /**
      * @internal
      */
+    #[\ReturnTypeWillChange]
     public function current()
     {
         return $this->forecasts[$this->position];
@@ -115,6 +117,7 @@ class WeatherForecast implements \Iterator
     /**
      * @internal
      */
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return $this->position;
@@ -123,6 +126,7 @@ class WeatherForecast implements \Iterator
     /**
      * @internal
      */
+    #[\ReturnTypeWillChange]
     public function next()
     {
         ++$this->position;
@@ -131,6 +135,7 @@ class WeatherForecast implements \Iterator
     /**
      * @internal
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return isset($this->forecasts[$this->position]);


### PR DESCRIPTION
Since the library is meant to support php 7.1, some attributes were added to methods in a few classes (CurrentWeatherGroup, WeatherForecast and Forecast), fixing deprecations errors being thrown on php 8.1